### PR TITLE
Tests fix for new sc version

### DIFF
--- a/test/KitchenSink.Tests/Test/SectionArray/DatagridPageTest.cs
+++ b/test/KitchenSink.Tests/Test/SectionArray/DatagridPageTest.cs
@@ -30,17 +30,9 @@ namespace KitchenSink.Tests.Test.SectionArray
         [Test]
         public void TablePage_AddNewRow()
         {
-            if (_browser == Config.Browser.Chrome)
-                WaitUntil(x => _datagridPage.CheckTableVisible());
-            else
-                WaitUntil(x => _datagridPage.PetsTable.Displayed);
-            
+            WaitUntil(x => _datagridPage.CheckTableVisible());
             _datagridPage.AddPet();
-
-            if (_browser == Config.Browser.Chrome)
-                WaitUntil(x => _datagridPage.GetTableRowsCount() == 4);
-            else
-                WaitUntil(x => _datagridPage.PetsTableRows.Count == 4);
+            WaitUntil(x => _datagridPage.GetTableRowsCount() == 4);
         }
     }
 }

--- a/test/KitchenSink.Tests/Test/SectionArray/DatagridPageTest.cs
+++ b/test/KitchenSink.Tests/Test/SectionArray/DatagridPageTest.cs
@@ -13,9 +13,11 @@ namespace KitchenSink.Tests.Test.SectionArray
     {
         private DatagridPage _datagridPage;
         private MainPage _mainPage;
+        private readonly Config.Browser _browser;
 
         public DatagridPageTest(Config.Browser browser) : base(browser)
         {
+            _browser = browser;
         }
 
         [SetUp]
@@ -28,10 +30,17 @@ namespace KitchenSink.Tests.Test.SectionArray
         [Test]
         public void TablePage_AddNewRow()
         {
-            var rowsBefore = _datagridPage.PetsTableRows.Count;
+            if (_browser == Config.Browser.Chrome)
+                WaitUntil(x => _datagridPage.CheckTableVisible());
+            else
+                WaitUntil(x => _datagridPage.PetsTable.Displayed);
+            
             _datagridPage.AddPet();
-            var rowsAfter = _datagridPage.PetsTableRows.Count;
-            Assert.Greater(rowsAfter, rowsBefore);
+
+            if (_browser == Config.Browser.Chrome)
+                WaitUntil(x => _datagridPage.GetTableRowsCount() == 4);
+            else
+                WaitUntil(x => _datagridPage.PetsTableRows.Count == 4);
         }
     }
 }

--- a/test/KitchenSink.Tests/Test/SectionArray/TablePageTest.cs
+++ b/test/KitchenSink.Tests/Test/SectionArray/TablePageTest.cs
@@ -29,11 +29,8 @@ namespace KitchenSink.Tests.Test.SectionArray
         public void TablePage_AddNewRow()
         {
             WaitUntil(x => _tablePage.PetsTable.Displayed);
-
-            var rowsBefore = _tablePage.PetsTableRows.Count;
             _tablePage.AddPet();
-            var rowsAfter = _tablePage.PetsTableRows.Count;
-            Assert.Greater(rowsAfter, rowsBefore);
+            WaitUntil(x => _tablePage.PetsTableRows.Count == 4);
         }
     }
 }

--- a/test/KitchenSink.Tests/Test/SectionArray/TablePageTest.cs
+++ b/test/KitchenSink.Tests/Test/SectionArray/TablePageTest.cs
@@ -28,6 +28,7 @@ namespace KitchenSink.Tests.Test.SectionArray
         [Test]
         public void TablePage_AddNewRow()
         {
+            WaitUntil(x => _tablePage.PetsTable.Displayed);
 
             var rowsBefore = _tablePage.PetsTableRows.Count;
             _tablePage.AddPet();

--- a/test/KitchenSink.Tests/Test/SectionCustom/FileUploadPageTest.cs
+++ b/test/KitchenSink.Tests/Test/SectionCustom/FileUploadPageTest.cs
@@ -14,9 +14,11 @@ namespace KitchenSink.Tests.Test.SectionCustom
     {
         private FileUploadPage _fileUploadPage;
         private MainPage _mainPage;
+        private readonly Config.Browser _browser;
 
         public FileUploadPageTest(Config.Browser browser) : base(browser)
         {
+            _browser = browser;
         }
 
         [SetUp]
@@ -29,7 +31,10 @@ namespace KitchenSink.Tests.Test.SectionCustom
         [Test]
         public void FileUploadPage_UploadAFile()
         {
-            WaitUntil(x => _fileUploadPage.FileInput.Enabled);
+            if (_browser == Config.Browser.Chrome)
+                WaitUntil(x => _fileUploadPage.CheckFileInputVisible());
+            else
+                WaitUntil(x => _fileUploadPage.FileInput.Enabled);
 
             string tempFilePath = Path.GetTempFileName();
             using (StreamWriter outputFile = new StreamWriter(tempFilePath, false))
@@ -37,16 +42,24 @@ namespace KitchenSink.Tests.Test.SectionCustom
                 outputFile.WriteLine("Test123");
             }
 
-            _fileUploadPage.UploadAFile(tempFilePath);
+            if (_browser == Config.Browser.Chrome)
+                _fileUploadPage.UploadAFileShadowRoot(tempFilePath);
+            else
+                _fileUploadPage.UploadAFile(tempFilePath);
+
             WaitUntil(x => _fileUploadPage.GetUploadedFilesCount() > 0);
 
-            Assert.AreEqual("Do not forget to delete files from your temporary folder!", _fileUploadPage.InfoLabel.Text);
+            Assert.AreEqual("Do not forget to delete files from your temporary folder!",
+                _fileUploadPage.InfoLabel.Text);
         }
 
         [Test]
         public void FileUploadPage_UploadAndDeleteAFile()
         {
-            WaitUntil(x => _fileUploadPage.FileInput.Enabled);
+            if (_browser == Config.Browser.Chrome)
+                WaitUntil(x => _fileUploadPage.CheckFileInputVisible());
+            else
+                WaitUntil(x => _fileUploadPage.FileInput.Enabled);
 
             string tempFilePath = Path.GetTempFileName();
             using (StreamWriter outputFile = new StreamWriter(tempFilePath, false))
@@ -54,7 +67,11 @@ namespace KitchenSink.Tests.Test.SectionCustom
                 outputFile.WriteLine("Test123");
             }
 
-            _fileUploadPage.UploadAFile(tempFilePath);
+            if (_browser == Config.Browser.Chrome)
+                _fileUploadPage.UploadAFileShadowRoot(tempFilePath);
+            else
+                _fileUploadPage.UploadAFile(tempFilePath);
+
             WaitUntil(x => _fileUploadPage.GetUploadedFilesCount() > 0);
 
             Assert.AreEqual("Do not forget to delete files from your temporary folder!", _fileUploadPage.InfoLabel.Text);

--- a/test/KitchenSink.Tests/Test/SectionCustom/FileUploadPageTest.cs
+++ b/test/KitchenSink.Tests/Test/SectionCustom/FileUploadPageTest.cs
@@ -31,21 +31,14 @@ namespace KitchenSink.Tests.Test.SectionCustom
         [Test]
         public void FileUploadPage_UploadAFile()
         {
-            if (_browser == Config.Browser.Chrome)
-                WaitUntil(x => _fileUploadPage.CheckFileInputVisible());
-            else
-                WaitUntil(x => _fileUploadPage.FileInput.Enabled);
+            WaitUntil(x => _fileUploadPage.CheckFileInputVisible());
 
             string tempFilePath = Path.GetTempFileName();
             using (StreamWriter outputFile = new StreamWriter(tempFilePath, false))
             {
                 outputFile.WriteLine("Test123");
             }
-
-            if (_browser == Config.Browser.Chrome)
-                _fileUploadPage.UploadAFileShadowRoot(tempFilePath);
-            else
-                _fileUploadPage.UploadAFile(tempFilePath);
+            _fileUploadPage.UploadAFile(tempFilePath);
 
             WaitUntil(x => _fileUploadPage.GetUploadedFilesCount() > 0);
 
@@ -56,21 +49,14 @@ namespace KitchenSink.Tests.Test.SectionCustom
         [Test]
         public void FileUploadPage_UploadAndDeleteAFile()
         {
-            if (_browser == Config.Browser.Chrome)
-                WaitUntil(x => _fileUploadPage.CheckFileInputVisible());
-            else
-                WaitUntil(x => _fileUploadPage.FileInput.Enabled);
+            WaitUntil(x => _fileUploadPage.CheckFileInputVisible());
 
             string tempFilePath = Path.GetTempFileName();
             using (StreamWriter outputFile = new StreamWriter(tempFilePath, false))
             {
                 outputFile.WriteLine("Test123");
             }
-
-            if (_browser == Config.Browser.Chrome)
-                _fileUploadPage.UploadAFileShadowRoot(tempFilePath);
-            else
-                _fileUploadPage.UploadAFile(tempFilePath);
+            _fileUploadPage.UploadAFile(tempFilePath);
 
             WaitUntil(x => _fileUploadPage.GetUploadedFilesCount() > 0);
 

--- a/test/KitchenSink.Tests/Ui/BasePage.cs
+++ b/test/KitchenSink.Tests/Ui/BasePage.cs
@@ -93,7 +93,12 @@ namespace KitchenSink.Tests.Ui
         public IWebElement ExpandShadowRoot(IWebElement shadowRootElement)
         {
             IWebElement shadowTreeParent = (IWebElement)((IJavaScriptExecutor)Driver)
-            .ExecuteScript("return arguments[0].shadowRoot", shadowRootElement);
+           .ExecuteScript("return arguments[0].shadowRoot", shadowRootElement);
+            if (shadowTreeParent == null)
+            {
+                //Shadow DOM not supported, fall back to DOM
+                return shadowRootElement;
+            }
             return shadowTreeParent;
         }
 

--- a/test/KitchenSink.Tests/Ui/BasePage.cs
+++ b/test/KitchenSink.Tests/Ui/BasePage.cs
@@ -90,6 +90,13 @@ namespace KitchenSink.Tests.Ui
             element.Click();
         }
 
+        public IWebElement ExpandShadowRoot(IWebElement shadowRootElement)
+        {
+            IWebElement shadowTreeParent = (IWebElement)((IJavaScriptExecutor)Driver)
+            .ExecuteScript("return arguments[0].shadowRoot", shadowRootElement);
+            return shadowTreeParent;
+        }
+
         public void ScrollToTheTop()
         {
             ((IJavaScriptExecutor)Driver).ExecuteScript("window.scrollTo(0, 0)");

--- a/test/KitchenSink.Tests/Ui/SectionArray/DatagridPage.cs
+++ b/test/KitchenSink.Tests/Ui/SectionArray/DatagridPage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.Remoting.Messaging;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Support.PageObjects;
 
@@ -14,8 +15,23 @@ namespace KitchenSink.Tests.Ui.SectionArray
         [FindsBy(How = How.XPath, Using = "//button[text() = 'Add a pet']")]
         public IWebElement AddPetButton { get; set; }
 
+        [FindsBy(How = How.ClassName, Using = "htCore")]
+        public IWebElement PetsTable { get; set; }
+
         [FindsBy(How = How.XPath, Using = "//table[@class='htCore']//tbody//tr")]
         public IList<IWebElement> PetsTableRows { get; set; }
+
+        public bool CheckTableVisible()
+        {
+            var shadowRoot = ExpandShadowRoot(Driver.FindElement(By.XPath("//hot-table")));
+            return shadowRoot.FindElement(By.ClassName("htCore")).Displayed;
+        }
+
+        public int GetTableRowsCount()
+        {
+            var shadowRoot = ExpandShadowRoot(Driver.FindElement(By.XPath("//hot-table")));
+            return shadowRoot.FindElement(By.ClassName("htCore")).FindElements(By.XPath("tbody//tr")).Count;
+        }
 
         public void AddPet()
         {

--- a/test/KitchenSink.Tests/Ui/SectionArray/DatagridPage.cs
+++ b/test/KitchenSink.Tests/Ui/SectionArray/DatagridPage.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.Remoting.Messaging;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Support.PageObjects;
 
@@ -14,12 +13,6 @@ namespace KitchenSink.Tests.Ui.SectionArray
 
         [FindsBy(How = How.XPath, Using = "//button[text() = 'Add a pet']")]
         public IWebElement AddPetButton { get; set; }
-
-        [FindsBy(How = How.ClassName, Using = "htCore")]
-        public IWebElement PetsTable { get; set; }
-
-        [FindsBy(How = How.XPath, Using = "//table[@class='htCore']//tbody//tr")]
-        public IList<IWebElement> PetsTableRows { get; set; }
 
         public bool CheckTableVisible()
         {

--- a/test/KitchenSink.Tests/Ui/SectionArray/TablePage.cs
+++ b/test/KitchenSink.Tests/Ui/SectionArray/TablePage.cs
@@ -14,6 +14,9 @@ namespace KitchenSink.Tests.Ui.SectionArray
         [FindsBy(How = How.XPath, Using = "//button[text() = 'Add a pet']")]
         public IWebElement AddPetButton { get; set; }
 
+        [FindsBy(How = How.XPath, Using = "//table[@class='table table-striped']")]
+        public IWebElement PetsTable { get; set; }
+
         [FindsBy(How = How.XPath, Using = "//table[@class='table table-striped']//tbody//tr")]
         public IList<IWebElement> PetsTableRows { get; set; }
 

--- a/test/KitchenSink.Tests/Ui/SectionCustom/FileUploadPage.cs
+++ b/test/KitchenSink.Tests/Ui/SectionCustom/FileUploadPage.cs
@@ -28,9 +28,21 @@ namespace KitchenSink.Tests.Ui.SectionCustom
             FileInput.SendKeys(filePath); //BUG in EDGE: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7194303/
         }
 
+        public void UploadAFileShadowRoot(string filePath)
+        {
+            var shadowRoot = ExpandShadowRoot(Driver.FindElement(By.XPath("//starcounter-upload")));
+            shadowRoot.FindElement(By.Id("fileElement")).SendKeys(filePath);
+        }
+
         public int GetUploadedFilesCount()
         {
             return UploadedFilesList.Count;
+        }
+
+        public bool CheckFileInputVisible()
+        {
+            var shadowRoot = ExpandShadowRoot(Driver.FindElement(By.XPath("//starcounter-upload")));
+            return shadowRoot.FindElement(By.Id("fileElement")).Enabled;
         }
 
         public void DeleteAllFiles()

--- a/test/KitchenSink.Tests/Ui/SectionCustom/FileUploadPage.cs
+++ b/test/KitchenSink.Tests/Ui/SectionCustom/FileUploadPage.cs
@@ -11,9 +11,6 @@ namespace KitchenSink.Tests.Ui.SectionCustom
             PageFactory.InitElements(Driver, this);
         }
 
-        [FindsBy(How = How.Id, Using = "fileElement")]
-        public IWebElement FileInput { get; set; }
-
         [FindsBy(How = How.CssSelector, Using = ".alert-warning")]
         public IWebElement InfoLabel { get; set; }
 
@@ -24,11 +21,6 @@ namespace KitchenSink.Tests.Ui.SectionCustom
         public IList<IWebElement> DeleteButtons { get; set; }
 
         public void UploadAFile(string filePath)
-        {
-            FileInput.SendKeys(filePath); //BUG in EDGE: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7194303/
-        }
-
-        public void UploadAFileShadowRoot(string filePath)
         {
             var shadowRoot = ExpandShadowRoot(Driver.FindElement(By.XPath("//starcounter-upload")));
             shadowRoot.FindElement(By.Id("fileElement")).SendKeys(filePath);


### PR DESCRIPTION
In Starcounter version 2.3 kitchensink display some elements in #shadow-root.
This is a fix for tests on google chrome for data grid page and upload file page.