### PR TITLE
Pass along parameters to star (run.bat)

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -2,4 +2,4 @@
 
 IF "%CONFIGURATION%"=="" SET CONFIGURATION=Debug
 
-star --resourcedir="%~dp0src\KitchenSink\wwwroot" "%~dp0src/KitchenSink/bin/%CONFIGURATION%/KitchenSink.exe"
+star %* --resourcedir="%~dp0src\KitchenSink\wwwroot" "%~dp0src/KitchenSink/bin/%CONFIGURATION%/KitchenSink.exe"


### PR DESCRIPTION
Pass along parameters to star (run.bat); for Starcounter/Guidelines#31 .