### PR TITLE
Add declarative shadow dom

### DIFF
--- a/src/KitchenSink/wwwroot/KitchenSink/AppIcon.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/AppIcon.html
@@ -1,3 +1,6 @@
 ﻿<template>
     <img slot="kitchensink/kitchensink-app-icon-image" src="/KitchenSink/images/KitchenSink.svg">
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/kitchensink-app-icon-image"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/BreadcrumbPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/BreadcrumbPage.html
@@ -54,4 +54,18 @@
 
         <button slot="kitchensink/breadcrumb-name-save" class="btn btn-sm btn-default" value="{{model.CurrentTreeItem.SaveTrigger$::click}}" onmousedown="++this.value">Save</button>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/breadcrumb-heading"></slot>
+        <slot name="kitchensink/breadcrumb-simple-breadcrumb-heading"></slot>
+        <slot name="kitchensink/breadcrumb-simple-breadcrumb-description"></slot>
+        <slot name="kitchensink/breadcrumb-simple-breadcrumb"></slot>
+        <slot name="kitchensink/breadcrumb-navigation-breadcrumb-heading"></slot>
+        <slot name="kitchensink/breadcrumb-navigation-breadcrumb-description"></slot>
+        <slot name="kitchensink/breadcrumb-navigation-breadcrumb"></slot>
+        <slot name="kitchensink/breadcrumb-adding-heading"></slot>
+        <slot name="kitchensink/breadcrumb-editing-heading"></slot>
+        <slot name="kitchensink/breadcrumb-name-heading"></slot>
+        <slot name="kitchensink/breadcrumb-name-input"></slot>
+        <slot name="kitchensink/breadcrumb-name-save"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/BreadcrumbPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/BreadcrumbPage.html
@@ -39,12 +39,12 @@
             </template>
         </x-breadcrumb>
         <div slot="kitchensink/breadcrumb-adding-heading">
-            <template slot="kitchensink/breadcrumb-adding-heading" is="dom-if" if="{{model.CurrentTreeItem.IsAdd}}" restamp>
+            <template is="dom-if" if="{{model.CurrentTreeItem.IsAdd}}" restamp>
                 <h5>Adding a new type in <strong>{{model.CurrentTreeItem.ParentName}}</strong></h5>
             </template>
         </div>
         <div slot="kitchensink/breadcrumb-editing-heading">
-            <template slot="kitchensink/breadcrumb-editing-heading" is="dom-if" if="{{!model.CurrentTreeItem.IsAdd}}" restamp>
+            <template is="dom-if" if="{{!model.CurrentTreeItem.IsAdd}}" restamp>
                 <h5>Editing <strong>{{model.CurrentTreeItem.Name$}}</strong></h5>
             </template>
         </div>

--- a/src/KitchenSink/wwwroot/KitchenSink/ButtonPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/ButtonPage.html
@@ -78,4 +78,30 @@
             };
         })();
     </script>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/buttonpage-heading"></slot>
+        <slot name="kitchensink/buttonpage-description"></slot>
+        <slot name="kitchensink/buttonpage-regular-heading"></slot>
+        <slot name="kitchensink/buttonpage-regular-description"></slot>
+        <slot name="kitchensink/buttonpage-regular-increment-label"></slot>
+        <slot name="kitchensink/buttonpage-regular-increment-ways"></slot>
+        <slot name="kitchensink/buttonpage-regular-reaction-label"></slot>
+        <slot name="kitchensink/buttonpage-regular-add-carrots"></slot>
+        <slot name="kitchensink/buttonpage-switch-heading"></slot>
+        <slot name="kitchensink/buttonpage-switch-description"></slot>
+        <slot name="kitchensink/buttonpage-switch-button"></slot>
+        <slot name="kitchensink/buttonpage-switch-reaction-label"></slot>
+        <slot name="kitchensink/buttonpage-disable-heading"></slot>
+        <slot name="kitchensink/buttonpage-disable-description"></slot>
+        <slot name="kitchensink/buttonpage-disable-button"></slot>
+        <slot name="kitchensink/buttonpage-disable-label"></slot>
+        <slot name="kitchensink/buttonpage-self-heading"></slot>
+        <slot name="kitchensink/buttonpage-self-reaction-label"></slot>
+        <slot name="kitchensink/buttonpage-self-button"></slot>
+        <slot name="kitchensink/buttonpage-binding-issue-heading"></slot>
+        <slot name="kitchensink/buttonpage-binding-issue-description"></slot>
+        <slot name="kitchensink/buttonpage-binding-issue-click-label"></slot>
+        <slot name="kitchensink/buttonpage-binding-issue-button"></slot>
+        <slot name="kitchensink/buttonpage-binding-issue-label"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/ChartPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/ChartPage.html
@@ -8,6 +8,11 @@
         
         <kitchensink-chart slot="kitchensink/chartpage-chart" temperatures="{{model.Temperatures}}" labels="{{model.Labels}}"></kitchensink-chart>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/chartpage-heading"></slot>
+        <slot name="kitchensink/chartpage-description"></slot>
+        <slot name="kitchensink/chartpage-chart"></slot>
+    </template>
 </template>
 
 <dom-module id="kitchensink-chart">

--- a/src/KitchenSink/wwwroot/KitchenSink/CheckboxPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/CheckboxPage.html
@@ -10,4 +10,11 @@
 
         <div slot="kitchensink/checkbox-license-label" class="kitchensink-test-driver-license-label">{{model.DrivingLicenseReaction}}</div>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/checkbox-heading"></slot>
+        <slot name="kitchensink/checkbox-description"></slot>
+        <slot name="kitchensink/checkbox-label"></slot>
+        <slot name="kitchensink/checkbox-input"></slot>
+        <slot name="kitchensink/checkbox-license-label"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/ClientLocalStatePage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/ClientLocalStatePage.html
@@ -17,6 +17,10 @@
             </template>
         </ul>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/clientlocalstatepage-heading"></slot>
+        <slot name="kitchensink/clientlocalstatepage-description"></slot>
+    </template>
 </template>
 
 <dom-module is="define-local">

--- a/src/KitchenSink/wwwroot/KitchenSink/CookiePage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/CookiePage.html
@@ -32,4 +32,11 @@
             };
         })();
     </script>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/cookie-heading"></slot>
+        <slot name="kitchensink/cookie-description"></slot>
+        <slot name="kitchensink/cookie-request-label"></slot>
+        <slot name="kitchensink/cookie-side-label"></slot>
+        <slot name="kitchensink/cookie-button"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/DatagridPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/DatagridPage.html
@@ -28,4 +28,10 @@
             }
         });
     </script>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/datagrid-heading"></slot>
+        <slot name="kitchensink/datagrid-description"></slot>
+        <slot name="kitchensink/datagrid-table"></slot>
+        <slot name="kitchensink/datagrid-button"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/DatepickerPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/DatepickerPage.html
@@ -23,4 +23,16 @@
 
         <input slot="kitchensink/datepicker-day-input" type="text" value="{{model.Day}}" readonly="readonly" class="form-control kitchensink-test-day-input" />
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/datepicker-heading"></slot>
+        <slot name="kitchensink/datepicker-description"></slot>
+        <slot name="kitchensink/datepicker-date-label"></slot>
+        <slot name="kitchensink/datepicker-pikaday"></slot>
+        <slot name="kitchensink/datepicker-year-label"></slot>
+        <slot name="kitchensink/datepicker-year-input"></slot>
+        <slot name="kitchensink/datepicker-month-label"></slot>
+        <slot name="kitchensink/datepicker-month-input"></slot>
+        <slot name="kitchensink/datepicker-day-label"></slot>
+        <slot name="kitchensink/datepicker-day-input"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/DecimalPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/DecimalPage.html
@@ -12,4 +12,11 @@
 
         <input slot="kitchensink/decimal-input" type="number" step="0.01" value="{{model.Price$::input}}" placeholder="Price" class="form-control"/>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/decimal-heading"></slot>
+        <slot name="kitchensink/decimal-description"></slot>
+        <slot name="kitchensink/decimal-info"></slot>
+        <slot name="kitchensink/decimal-label"></slot>
+        <slot name="kitchensink/decimal-input"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/FileUploadPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/FileUploadPage.html
@@ -138,4 +138,19 @@
             };
         })();
     </script>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/fileupload-heading"></slot>
+        <slot name="kitchensink/fileupload-description"></slot>
+        <slot name="kitchensink/fileupload-warning"></slot>
+        <slot name="kitchensink/fileupload-upload-file-header"></slot>
+        <slot name="kitchensink/fileupload-files-table"></slot>
+        <slot name="kitchensink/fileupload-no-files-message"></slot>
+        <slot name="kitchensink/fileupload-uploading-header"></slot>
+        <slot name="kitchensink/fileupload-uploading-table"></slot>
+        <slot name="kitchensink/fileupload-ongoing-message"></slot>
+        <slot name="kitchensink/fileupload-upload"></slot>
+        <slot name="kitchensink/fileupload-select-button"></slot>
+        <slot name="kitchensink/fileupload-cancel-button"></slot>
+        <slot name="kitchensink/fileupload-tasks-collection"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/GeoPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/GeoPage.html
@@ -13,4 +13,10 @@
         </google-map>
         <button slot="kitchensink/geo-reset-button" value="{{model.Position.ResetTrigger$::click}}" onclick="this.value++" class="btn btn-primary">Reset</button>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/geo-heading"></slot>
+        <slot name="kitchensink/geo-description"></slot>
+        <slot name="kitchensink/geo-google-map"></slot>
+        <slot name="kitchensink/geo-reset-button"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/HtmlPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/HtmlPage.html
@@ -10,4 +10,9 @@
             </template>
         </div>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/html-heading"></slot>
+        <slot name="kitchensink/html-description"></slot>
+        <slot name="kitchensink/html-juicy-html"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/IntegerPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/IntegerPage.html
@@ -10,4 +10,11 @@
 
         <input slot="kitchensink/integer-input" type="number" value="{{model.Age$::input}}" placeholder="Age" class="form-control">
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/integer-heading"></slot>
+        <slot name="kitchensink/integer-description"></slot>
+        <slot name="kitchensink/integer-info"></slot>
+        <slot name="kitchensink/integer-label"></slot>
+        <slot name="kitchensink/integer-input"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/LazyLoadingPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/LazyLoadingPage.html
@@ -94,4 +94,11 @@
             }
         })();
     </script>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/lazyLoading-heading"></slot>
+        <slot name="kitchensink/lazyLoading-scheduling-description"></slot>
+        <slot name="kitchensink/lazyLoading-table-description"></slot>
+        <slot name="kitchensink/lazyLoading-table"></slot>
+        <slot name="kitchensink/lazyLoading-message-box"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/MainPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/MainPage.html
@@ -2,4 +2,9 @@
     <h1 slot="kitchensink/main-heading" class="kitchensink-heading-1">Welcome to KitchenSink</h1>
 
     <p slot="kitchensink/main-description">Use the menu on the left to browse various examples of how to build web-based UI with Starcounter and Polymer.</p>
+
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/main-heading"></slot>
+        <slot name="kitchensink/main-description"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/MarkdownPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/MarkdownPage.html
@@ -6,4 +6,9 @@
         <p slot="kitchensink/markdownd-description">JSON's primitive value type <code>string</code> can be rendered as Markdown using a helper custom element, such as <a href="http://github.com/juicy/juicy-markdown">juicy-markdown</a>.</p>
         <juicy-markdown slot="kitchensink/markdownd-juicy-markdown" value="{{model.Bio}}"></juicy-markdown>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/markdownd-heading"></slot>
+        <slot name="kitchensink/markdownd-description"></slot>
+        <slot name="kitchensink/markdownd-juicy-markdown"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/MasterPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/MasterPage.html
@@ -3,4 +3,7 @@
     <template id="root" is="dom-bind">
         <starcounter-include slot="kitchensink/master-current-page" partial="{{model.CurrentPage}}"></starcounter-include>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/master-current-page"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/MultiselectPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/MultiselectPage.html
@@ -29,4 +29,13 @@
             Your favorite country is: <span>{{model.FavoriteCountry$}}</span>
         </p>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/multiselect-heading"></slot>
+        <slot name="kitchensink/multiselect-description"></slot>
+        <slot name="kitchensink/multiselect-countries-multiselect"></slot>
+        <slot name="kitchensink/multiselect-visited-label"></slot>
+        <slot name="kitchensink/multiselect-favorite-country-select-label"></slot>
+        <slot name="kitchensink/multiselect-favorite-country-select"></slot>
+        <slot name="kitchensink/multiselect-favorite-label"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/NavPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/NavPage.html
@@ -54,4 +54,7 @@
             </div>
         </div>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/nav-navigation"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/PaginationPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/PaginationPage.html
@@ -91,4 +91,11 @@
             };
         })();
     </script>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/pagination-heading"></slot>
+        <slot name="kitchensink/pagination-description"></slot>
+        <slot name="kitchensink/pagination-juicy-select-items-per-page"></slot>
+        <slot name="kitchensink/pagination-navigation"></slot>
+        <slot name="kitchensink/pagination-page-number"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/PasswordPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/PasswordPage.html
@@ -10,4 +10,11 @@
 
         <input slot="kitchensink/password-input" type="password" value="{{model.Password$::input}}" placeholder="Password" class="form-control kitchensink-test-password-input">
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/password-heading"></slot>
+        <slot name="kitchensink/password-description"></slot>
+        <slot name="kitchensink/password-note"></slot>
+        <slot name="kitchensink/password-label"></slot>
+        <slot name="kitchensink/password-input"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/ProgressBarPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/ProgressBarPage.html
@@ -18,4 +18,11 @@
             </template>
         </p>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/progressBar-heading"></slot>
+        <slot name="kitchensink/progressBar-description"></slot>
+        <slot name="kitchensink/progressBar-read-more"></slot>
+        <slot name="kitchensink/progressBar-progress-bar"></slot>
+        <slot name="kitchensink/progressBar-button-area"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/RadioPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/RadioPage.html
@@ -17,4 +17,11 @@
 
         <div slot="kitchensink/radio-reaction-label" class="kitchensink-test-pet-reaction-label">{{model.PetReaction}}</div>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/radio-heading"></slot>
+        <slot name="kitchensink/radio-description"></slot>
+        <slot name="kitchensink/radio-description-recommend"></slot>
+        <slot name="kitchensink/radio-paper-radio-group"></slot>
+        <slot name="kitchensink/radio-reaction-label"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/RedirectPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/RedirectPage.html
@@ -35,4 +35,23 @@
         <link slot="kitchensink/redirect-link-morph" is="puppet-redirect" history url$="{{model.MorphUrl$}}" />
         <link slot="kitchensink/redirect-link-redirect" is="puppet-redirect" url$="{{model.RedirectUrl$}}" />
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/redirect-heading"></slot>
+        <slot name="kitchensink/redirect-description"></slot>
+        <slot name="kitchensink/redirect-current-partial-heading"></slot>
+        <slot name="kitchensink/redirect-current-partial-description"></slot>
+        <slot name="kitchensink/redirect-current-partial-label"></slot>
+        <slot name="kitchensink/redirect-current-partial-fruit-button"></slot>
+        <slot name="kitchensink/redirect-current-partial-vegetable-button"></slot>
+        <slot name="kitchensink/redirect-current-partial-bread-button"></slot>
+        <slot name="kitchensink/redirect-current-partial-favorite-label"></slot>
+        <slot name="kitchensink/redirect-another-partial-heading"></slot>
+        <slot name="kitchensink/redirect-another-partial-description"></slot>
+        <slot name="kitchensink/redirect-another-partial-button"></slot>
+        <slot name="kitchensink/redirect-external-link-heading"></slot>
+        <slot name="kitchensink/redirect-external-link-description"></slot>
+        <slot name="kitchensink/redirect-external-link-button"></slot>
+        <slot name="kitchensink/redirect-link-morph"></slot>
+        <slot name="kitchensink/redirect-link-redirect"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/TablePage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/TablePage.html
@@ -22,4 +22,10 @@
         </table>
         <button slot="kitchensink/table-button" class="btn btn-sm btn-default" value="{{model.AddPetTrigger$::click}}" onmousedown="++this.value">Add a pet</button>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/table-heading"></slot>
+        <slot name="kitchensink/table-description"></slot>
+        <slot name="kitchensink/table-table"></slot>
+        <slot name="kitchensink/table-button"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/TextPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/TextPage.html
@@ -30,4 +30,20 @@
 
         <paper-input slot="kitchensink/text-typing-listening-paper-input" label="{{model.NameForPaperLiveReaction}}" value="{{model.NameForPaperLive$::value-changed}}" class="kitchensink-test-name-paper-input-dynamic"></paper-input>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/text-heading"></slot>
+        <slot name="kitchensink/text-description"></slot>
+        <slot name="kitchensink/text-listening-heading"></slot>
+        <slot name="kitchensink/text-listening-description"></slot>
+        <slot name="kitchensink/text-listening-label"></slot>
+        <slot name="kitchensink/text-listening-input"></slot>
+        <slot name="kitchensink/text-typing-listening-heading"></slot>
+        <slot name="kitchensink/text-typing-listening-description"></slot>
+        <slot name="kitchensink/text-typing-listening-label"></slot>
+        <slot name="kitchensink/text-typing-listening-input"></slot>
+        <slot name="kitchensink/text-listening-paper-label"></slot>
+        <slot name="kitchensink/text-listening-paper-input"></slot>
+        <slot name="kitchensink/text-typing-listening-paper-label"></slot>
+        <slot name="kitchensink/text-typing-listening-paper-input"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/TextareaPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/TextareaPage.html
@@ -8,4 +8,10 @@
 
         <textarea slot="kitchensink/textarea-textarea" test-value$="{{model.Bio$}}" value="{{model.Bio$::input}}" class="form-control kitchensink-test-textarea" rows="3"></textarea>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/textarea-heading"></slot>
+        <slot name="kitchensink/textarea-description"></slot>
+        <slot name="kitchensink/textarea-label"></slot>
+        <slot name="kitchensink/textarea-textarea"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/ToggleButtonPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/ToggleButtonPage.html
@@ -10,4 +10,10 @@
 
         <paper-toggle-button slot="kitchensink/toggleButton-toggle-button" class="kitchensink-test-tooglebutton" checked="{{model.AcceptTermsAndConditions$::change}}"></paper-toggle-button>
     </template>
+    <template is="declarative-shadow-dom">
+        <slot name="kitchensink/toggleButton-heading"></slot>
+        <slot name="kitchensink/toggleButton-description"></slot>
+        <slot name="kitchensink/toggleButton-label"></slot>
+        <slot name="kitchensink/toggleButton-toggle-button"></slot>
+    </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/UrlPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/UrlPage.html
@@ -4,9 +4,7 @@
 
         <p slot="kitchensink/url-description">JSON's primitive value type <code>string</code> can be mapped directly to HTML <code>a href=""</code>.</p>
 
-        <p>
             <a slot="kitchensink/url-link" href="{{model.Url}}">{{model.Label}}</a>
-        </p>
     </template>
     <template is="declarative-shadow-dom">
         <slot name="kitchensink/url-heading"></slot>

--- a/src/KitchenSink/wwwroot/KitchenSink/UrlPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/UrlPage.html
@@ -4,7 +4,7 @@
 
         <p slot="kitchensink/url-description">JSON's primitive value type <code>string</code> can be mapped directly to HTML <code>a href=""</code>.</p>
 
-            <a slot="kitchensink/url-link" href="{{model.Url}}">{{model.Label}}</a>
+        <a slot="kitchensink/url-link" href="{{model.Url}}">{{model.Label}}</a>
     </template>
     <template is="declarative-shadow-dom">
         <slot name="kitchensink/url-heading"></slot>

--- a/test/KitchenSink.Tests/Ui/NestedPartialsPage.cs
+++ b/test/KitchenSink.Tests/Ui/NestedPartialsPage.cs
@@ -14,7 +14,7 @@ namespace KitchenSink.Tests.Ui
         [FindsBy(How = How.XPath, Using = "//button[text() = 'Add child']")]
         public IWebElement AddChildButton { get; set; }
 
-        [FindsBy(How = How.XPath, Using = "//juicy-composition")]
+        [FindsBy(How = How.XPath, Using = "//starcounter-include")]
         public IList<IWebElement> ChildCompositions { get; set; }
 
         public void AddChild()


### PR DESCRIPTION
Changes are explained in the commit messages.

This should be merged to KitchenSink `develop` after the branch https://github.com/Starcounter/level1/tree/starcounter-include-CEv1 is merged to Starcounter `v2.3`. Otherwise KitchenSink does not render pages.

Last commit says "WIP" but actually it seems to be final change that is needed regarding `declarative-shadow-dom`.