### PR TITLE
Enhance Link Page and add tests for it

### DIFF
--- a/src/KitchenSink/wwwroot/KitchenSink/UrlPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/UrlPage.html
@@ -2,15 +2,15 @@
     <template is="dom-bind">
         <h1 slot="kitchensink/url-heading" class="kitchensink-heading-1">Link</h1>
 
-        <h6 slot="kitchensink/url-description">JSON's primitive value type <code>string</code> can be mapped directly to HTML <code>a href=""</code>.</h6>
+        <p slot="kitchensink/url-description">JSON's primitive value type <code>string</code> can be mapped directly to HTML <code>a href=""</code>.</p>
 
         <a slot="kitchensink/url-link" href="{{model.Url}}">{{model.Label}}</a>
 
-        <h6 slot="kitchensink/url-description-targeted">Setting any target except <code>_self</code> would disable page morphing</h6>
+        <p slot="kitchensink/url-description-targeted">Setting any target except <code>_self</code> would disable page morphing</p>
 
         <a slot="kitchensink/targeted-url-link" target="_black" href="{{model.Url}}">Targetted: {{model.Label}}</a>
 
-        <h6 slot="kitchensink/url-description-targeted-iframe">iframe targets are also supported</h6>
+        <p slot="kitchensink/url-description-targeted-iframe">iframe targets are also supported</p>
 
         <a slot="kitchensink/url-link-iframe-targetted" target="link-target" href="{{model.Url}}">iframe-targetted: {{model.Label}}</a>
         <iframe slot="kitchensink/url-targeted-iframe" id="link-target" name="link-target"></iframe>

--- a/src/KitchenSink/wwwroot/KitchenSink/UrlPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/UrlPage.html
@@ -2,15 +2,43 @@
     <template is="dom-bind">
         <h1 slot="kitchensink/url-heading" class="kitchensink-heading-1">Link</h1>
 
-        <p slot="kitchensink/url-description">JSON's primitive value type <code>string</code> can be mapped directly to HTML <code>a href=""</code>.</p>
+        <h6 slot="kitchensink/url-description">JSON's primitive value type <code>string</code> can be mapped directly to HTML <code>a href=""</code>.</h6>
 
         <a slot="kitchensink/url-link" href="{{model.Url}}">{{model.Label}}</a>
+
+        <h6 slot="kitchensink/url-description-targeted">Setting any target except <code>_self</code> would disable page morphing</h6>
+
+        <a slot="kitchensink/targeted-url-link" target="_black" href="{{model.Url}}">Targetted: {{model.Label}}</a>
+
+        <h6 slot="kitchensink/url-description-targeted-iframe">iframe targets are also supported</h6>
+
+        <a slot="kitchensink/url-link-iframe-targetted" target="link-target" href="{{model.Url}}">iframe-targetted: {{model.Label}}</a>
+        <iframe slot="kitchensink/url-targeted-iframe" id="link-target" name="link-target"></iframe>
+
     </template>
     <template is="declarative-shadow-dom">
         <slot name="kitchensink/url-heading"></slot>
-        <slot name="kitchensink/url-description"></slot>
-        <p>
-            <slot name="kitchensink/url-link"></slot>
-        </p>
+        <div>
+            <slot name="kitchensink/url-description"></slot>
+            <p>
+                <slot name="kitchensink/url-link"></slot>
+            </p>
+        </div>
+        <div>
+            <slot name="kitchensink/url-description-targeted"></slot>
+            <p>
+                <slot name="kitchensink/targeted-url-link"></slot>
+            </p>
+        </div>
+        <div>
+            <slot name="kitchensink/url-description-targeted-iframe"></slot>
+            <p>
+                <slot name="kitchensink/url-link-iframe-targetted"></slot>
+            </p>
+            <p>
+                <slot name="kitchensink/url-targeted-iframe"></slot>
+            </p>
+            <p><em><small>demo iframe</small></em></p>
+        </div>
     </template>
 </template>

--- a/test/KitchenSink.Tests/KitchenSink.Tests.csproj
+++ b/test/KitchenSink.Tests/KitchenSink.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Test\RadioPageTest.cs" />
     <Compile Include="Test\BaseTest.cs" />
     <Compile Include="Test\CheckboxPageTest.cs" />
+    <Compile Include="Test\UrlPageTest.cs" />
     <Compile Include="Test\ToggleButtonPageTest.cs" />
     <Compile Include="Test\AutoCompletePageTest.cs" />
     <Compile Include="Test\FileUploadPageTest.cs" />
@@ -89,6 +90,7 @@
     <Compile Include="Ui\BasePage.cs" />
     <Compile Include="Ui\ButtonPage.cs" />
     <Compile Include="Ui\CheckboxPage.cs" />
+    <Compile Include="Ui\UrlPage.cs" />
     <Compile Include="Ui\ToggleButtonPage.cs" />
     <Compile Include="Ui\AutoCompletePage.cs" />
     <Compile Include="Ui\FileUploadPage.cs" />

--- a/test/KitchenSink.Tests/Test/TextPageTest.cs
+++ b/test/KitchenSink.Tests/Test/TextPageTest.cs
@@ -1,5 +1,4 @@
 ﻿using KitchenSink.Tests.Ui;
-
 using KitchenSink.Tests.Utilities;
 using NUnit.Framework;
 using OpenQA.Selenium;

--- a/test/KitchenSink.Tests/Test/UrlPageTest.cs
+++ b/test/KitchenSink.Tests/Test/UrlPageTest.cs
@@ -11,7 +11,7 @@ namespace KitchenSink.Tests.Test
     [TestFixture(Config.Browser.Firefox)]
     internal class UrlPageTest : BaseTest
     {
-        private UrlPage _UrlPage;
+        private UrlPage _urlPage;
         private MainPage _mainPage;
 
         public UrlPageTest(Config.Browser browser) : base(browser)
@@ -22,54 +22,54 @@ namespace KitchenSink.Tests.Test
         public void SetUp()
         {
             _mainPage = new MainPage(Driver).GoToMainPage();
-            _UrlPage = _mainPage.GoToUrlPage();
+            _urlPage = _mainPage.GoToUrlPage();
         }
 
-        private string getIframeCurrentURL()
+        private string GetIframeCurrentURL()
         {
-            IJavaScriptExecutor JSExecuter = (IJavaScriptExecutor)Driver;
-            return (string)JSExecuter.ExecuteScript("return document.querySelector('#link-target').contentWindow.location.href");
+            IJavaScriptExecutor jsExecuter = (IJavaScriptExecutor)Driver;
+            return (string)jsExecuter.ExecuteScript("return document.querySelector('#link-target').contentWindow.location.href");
         }
 
         [TearDown]
         public void TeadDown()
         {
-            _UrlPage = _mainPage.GoToUrlPage();
+            _urlPage = _mainPage.GoToUrlPage();
         }
 
         [Test]
         public void UrlPage_ClickSimpleLink()
         {
-            IJavaScriptExecutor JSExecuter = (IJavaScriptExecutor)Driver;
-            WaitUntil(x => _UrlPage.SimpleMorphableLink.Displayed);
+            IJavaScriptExecutor jsExecuter = (IJavaScriptExecutor)Driver;
+            WaitUntil(x => _urlPage.SimpleMorphableLink.Displayed);
 
             // leave a foot print in the window object
-            JSExecuter.ExecuteScript("window.footprintExists = true");
+            jsExecuter.ExecuteScript("window.footprintExists = true");
 
             // control test 
             Assert.AreEqual("http://localhost:8080/KitchenSink/Url", Driver.Url);
-            Assert.AreEqual(true, JSExecuter.ExecuteScript("return window.footprintExists"));
+            Assert.AreEqual(true, jsExecuter.ExecuteScript("return window.footprintExists"));
 
-            _UrlPage.ClickSimpleMorphableLink();
+            _urlPage.ClickSimpleMorphableLink();
 
             System.Threading.Thread.Sleep(2000);
 
             Assert.AreEqual(Driver.Url, "http://localhost:8080/KitchenSink");
 
             // if the foot print still exists, we can infer that the page was actually morphed, not fully loaded
-            Assert.AreEqual(true, JSExecuter.ExecuteScript("return window.footprintExists"));
+            Assert.AreEqual(true, jsExecuter.ExecuteScript("return window.footprintExists"));
 
         }
         
         [Test]
         public void UrlPage_ClickBlankTargettedLink()
         {
-            WaitUntil(x => _UrlPage.BlankTargettedLink.Displayed);
+            WaitUntil(x => _urlPage.BlankTargettedLink.Displayed);
 
             //control test 
             Assert.AreEqual(Driver.WindowHandles.Count, 1);
 
-            _UrlPage.ClickBlankTargettedLink();
+            _urlPage.ClickBlankTargettedLink();
 
             System.Threading.Thread.Sleep(500);
 
@@ -86,16 +86,16 @@ namespace KitchenSink.Tests.Test
         [Test]
         public void UrlPage_ClickIframeTargettedLink()
         {
-            WaitUntil(x => _UrlPage.IframeTargettedLink != null && _UrlPage.IframeTargettedLink.Displayed);
+            WaitUntil(x => _urlPage.IframeTargettedLink != null && _urlPage.IframeTargettedLink.Displayed);
 
             //control test 
-            Assert.AreEqual(getIframeCurrentURL(), "about:blank");
+            Assert.AreEqual(GetIframeCurrentURL(), "about:blank");
 
-            _UrlPage.ClickIframeTargettedLink();
+            _urlPage.ClickIframeTargettedLink();
 
             System.Threading.Thread.Sleep(500);
 
-            Assert.AreEqual(getIframeCurrentURL(), "http://localhost:8080/KitchenSink");
+            Assert.AreEqual(GetIframeCurrentURL(), "http://localhost:8080/KitchenSink");
         }
     }
 }

--- a/test/KitchenSink.Tests/Test/UrlPageTest.cs
+++ b/test/KitchenSink.Tests/Test/UrlPageTest.cs
@@ -1,0 +1,101 @@
+﻿using KitchenSink.Tests.Ui;
+using KitchenSink.Tests.Utilities;
+using NUnit.Framework;
+using OpenQA.Selenium;
+
+namespace KitchenSink.Tests.Test
+{
+    [Parallelizable(ParallelScope.Fixtures)]
+    [TestFixture(Config.Browser.Chrome)]
+    [TestFixture(Config.Browser.Edge)]
+    [TestFixture(Config.Browser.Firefox)]
+    internal class UrlPageTest : BaseTest
+    {
+        private UrlPage _UrlPage;
+        private MainPage _mainPage;
+
+        public UrlPageTest(Config.Browser browser) : base(browser)
+        {
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mainPage = new MainPage(Driver).GoToMainPage();
+            _UrlPage = _mainPage.GoToUrlPage();
+        }
+
+        private string getIframeCurrentURL()
+        {
+            IJavaScriptExecutor JSExecuter = (IJavaScriptExecutor)Driver;
+            return (string)JSExecuter.ExecuteScript("return document.querySelector('#link-target').contentWindow.location.href");
+        }
+
+        [TearDown]
+        public void TeadDown()
+        {
+            _UrlPage = _mainPage.GoToUrlPage();
+        }
+
+        [Test]
+        public void UrlPage_ClickSimpleLink()
+        {
+            IJavaScriptExecutor JSExecuter = (IJavaScriptExecutor)Driver;
+            WaitUntil(x => _UrlPage.SimpleMorphableLink.Displayed);
+
+            // leave a foot print in the window object
+            JSExecuter.ExecuteScript("window.footprintExists = true");
+
+            // control test 
+            Assert.AreEqual("http://localhost:8080/KitchenSink/Url", Driver.Url);
+            Assert.AreEqual(true, JSExecuter.ExecuteScript("return window.footprintExists"));
+
+            _UrlPage.ClickSimpleMorphableLink();
+
+            System.Threading.Thread.Sleep(2000);
+
+            Assert.AreEqual(Driver.Url, "http://localhost:8080/KitchenSink");
+
+            // if the foot print still exists, we can infer that the page was actually morphed, not fully loaded
+            Assert.AreEqual(true, JSExecuter.ExecuteScript("return window.footprintExists"));
+
+        }
+        
+        [Test]
+        public void UrlPage_ClickBlankTargettedLink()
+        {
+            WaitUntil(x => _UrlPage.BlankTargettedLink.Displayed);
+
+            //control test 
+            Assert.AreEqual(Driver.WindowHandles.Count, 1);
+
+            _UrlPage.ClickBlankTargettedLink();
+
+            System.Threading.Thread.Sleep(500);
+
+            Assert.AreEqual(Driver.WindowHandles.Count, 2);
+
+            //close pop up
+            Driver.SwitchTo().Window(Driver.WindowHandles[1]);
+            Driver.Close();
+
+            // use the original page
+            Driver.SwitchTo().Window(Driver.WindowHandles[0]);
+        }
+
+        [Test]
+        public void UrlPage_ClickIframeTargettedLink()
+        {
+            WaitUntil(x => _UrlPage.IframeTargettedLink != null && _UrlPage.IframeTargettedLink.Displayed);
+
+            //control test 
+            Assert.AreEqual(getIframeCurrentURL(), "about:blank");
+
+            _UrlPage.ClickIframeTargettedLink();
+
+            System.Threading.Thread.Sleep(500);
+
+            Assert.AreEqual(getIframeCurrentURL(), "http://localhost:8080/KitchenSink");
+        }
+    }
+}

--- a/test/KitchenSink.Tests/Ui/BasePage.cs
+++ b/test/KitchenSink.Tests/Ui/BasePage.cs
@@ -33,6 +33,9 @@ namespace KitchenSink.Tests.Ui
         [FindsBy(How = How.XPath, Using = "//a[text() = 'Table']")]
         public IWebElement TablePageLink { get; set; }
 
+        [FindsBy(How = How.XPath, Using = "//a[text() = 'Link']")]
+        public IWebElement UrlPageLink { get; set; }
+
         [FindsBy(How = How.XPath, Using = "//a[text() = 'Validation']")]
         public IWebElement ValidationPageLink { get; set; }
 

--- a/test/KitchenSink.Tests/Ui/MainPage.cs
+++ b/test/KitchenSink.Tests/Ui/MainPage.cs
@@ -38,7 +38,11 @@ namespace KitchenSink.Tests.Ui
             ClickOn(TablePageLink);
             return new TablePage(Driver);
         }
-
+        public UrlPage GoToUrlPage()
+        {            
+            ClickOn(UrlPageLink);
+            return new UrlPage(Driver);
+        }
         public ValidationPage GoToValidationPage()
         {
             ClickOn(ValidationPageLink);

--- a/test/KitchenSink.Tests/Ui/UrlPage.cs
+++ b/test/KitchenSink.Tests/Ui/UrlPage.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.PageObjects;
+
+namespace KitchenSink.Tests.Ui
+{
+    public class UrlPage : BasePage
+    {  
+        public UrlPage(IWebDriver driver) : base(driver)
+        {
+            PageFactory.InitElements(Driver, this);
+        }
+
+        [FindsBy(How = How.XPath, Using = "//a[text() = 'This a sample link']")]
+        public IWebElement SimpleMorphableLink { get; set;  }
+
+        [FindsBy(How = How.XPath, Using = "//a[text() = 'Targetted: This a sample link']")]
+        public IWebElement BlankTargettedLink { get; set; }
+
+        [FindsBy(How = How.XPath, Using = "//a[text() = 'iframe-targetted: This a sample link']")]
+        public IWebElement IframeTargettedLink { get; set; }
+
+        public void ClickSimpleMorphableLink()
+        {
+            ClickOn(SimpleMorphableLink);
+        }
+        public void ClickBlankTargettedLink()
+        {
+            ClickOn(BlankTargettedLink);
+        }
+        public void ClickIframeTargettedLink()
+        {
+            ClickOn(IframeTargettedLink);
+        }
+
+    }
+}


### PR DESCRIPTION
Weirdly, there was no tests for **Link** page. I enhanced the page to contain more examples and added tests for the old and the new features.

Expectedly, tests will fail until https://github.com/Palindrom/Palindrom/pull/145 is added to Starcounter. Tests pass locally for sure (with Palindrom updated in ClientFiles).

I invested time in those tests because they will mean everything to me in the next steps.

## To test locally

1. Rename `Palindrom` folder in ClientFiles to `Palindrom - Backup`.
2. Clone [Palindrom ](https://github.com/Palindrom/Palindrom)inside ClientFiles. 
3. Run KitchenSink tests.

